### PR TITLE
🚀 Migrate to native uuid function (stop using extensions)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,6 +21,8 @@ It's not secured by default and run with `AUTH_TYPE=plain`, so you can specify t
 
 If you're using HMAC-based authentication (recommended), you need to specify `api-public-key`, `x-user-id` and `x-user-hmac` headers. Read more about it [here](https://notifir.github.io/docs/integration/authentication).
 
+Please note, that minimal supported version of `Postgresql` is 13.0, since `gen_random_uuid()` is used in migrations. Read more about it [here](https://www.postgresql.org/docs/13/functions-uuid.html).
+
 ## Development
 
 To start Notifir API locally you need to have database running. You can run the Postgres in a [docker container](https://hub.docker.com/_/postgres) using the following commands:

--- a/db/migrations/20220526103422_init.js
+++ b/db/migrations/20220526103422_init.js
@@ -14,12 +14,9 @@ const secrets = {
  module.exports.up = async (knex, Promise) => {
   console.info('running migration 20220526103422_init');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-  await knex.raw('create extension if not exists "pgcrypto"');
-
   await knex.schema
     .createTable('notifications', function (t) {
-      t.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v1mc()')).primary();
+      t.uuid('id').notNullable().defaultTo(knex.raw('gen_random_uuid()')).primary();
       t.string('type', 255).notNullable();
       t.boolean('read').defaultTo(false);
       t.json('payload').notNullable();

--- a/db/migrations/20220706100046_create_templates.js
+++ b/db/migrations/20220706100046_create_templates.js
@@ -5,11 +5,9 @@
 exports.up = async (knex) => {
   console.info('running migration 20220706100046_create_templates');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-
   await knex.schema
     .createTable('templates', function (t) {
-      t.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v1mc()')).primary();
+      t.uuid('id').notNullable().defaultTo(knex.raw('gen_random_uuid()')).primary();
       t.string('type', 255).notNullable();
       t.string('locale', 5).defaultTo('en-GB');
       t.string('content', 255).notNullable();

--- a/db/migrations/20220717183449_create_projects.js
+++ b/db/migrations/20220717183449_create_projects.js
@@ -5,13 +5,11 @@
  exports.up = async (knex) => {
   console.info('running migration 20220717183449_create_projects');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-
   await knex.schema
     .createTable('projects', function (t) {
       t.string('id').unique().notNullable().primary();
-      t.string('api_public_key', 255).unique().index().notNullable().defaultTo(knex.raw('uuid_generate_v1mc()'));
-      t.string('api_secret_key', 255).unique().notNullable().defaultTo(knex.raw('uuid_generate_v1mc()'));
+      t.string('api_public_key', 255).unique().index().notNullable().defaultTo(knex.raw('gen_random_uuid()'));
+      t.string('api_secret_key', 255).unique().notNullable().defaultTo(knex.raw('gen_random_uuid()'));
       t.boolean('enabled').defaultTo(true);
       t.timestamp('created_at').defaultTo(knex.fn.now());
     });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,9 +21,9 @@ services:
       - db
     networks:
       - notifir_network
-#   uncomment if you want to run init script
-#    volumes:
-#      - ./init.json:/notifir/api/init.json
+    # uncomment if you want to run init script
+    # volumes:
+    #   - ./init.example.json:/notifir/api/init.json
   db:
     container_name: notifir_db
     image: postgres


### PR DESCRIPTION
We're using `create extension` in the DB migrations, which requires `superuser` permission. The only reason for using custom extensions is `uuid` generation, which is available out of the box in Postgresql > 13.0 (https://www.postgresql.org/docs/13/functions-uuid.html). 