### PR TITLE
🔧 resolve dependency on the postgres superuser

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@ CLIENT=pg
 NODE_ENV=development
 
 DB_DATABASE=notifir
-DB_USER=postgres
-DB_PASSWORD=postgres
+DB_USER=notifir
+DB_PASSWORD=notifir
 DB_HOST=localhost
 DB_PORT=5432
 

--- a/README.MD
+++ b/README.MD
@@ -28,11 +28,17 @@ To start Notifir API locally you need to have database running. You can run the 
 ```bash
 
 docker pull postgres
-docker run --name postgres -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres
+docker run --name notifir-db -e POSTGRES_USER=notifir -e POSTGRES_PASSWORD=notifir -p 5432:5432 -d notifir
 
 ```
 
-Once you have a clean DB started, you can set up the data structure and generate seed data:
+Postgres is required to have `uuid-ossp` extension installed. Since the `superuser` permission is required to do that, you need to install it before running the migration and seed scripts.
+
+```bash
+psql -v ON_ERROR_STOP=1 -h localhost -p 5432 --username postgres --dbname notifir -c "create extension if not exists \"uuid-ossp\"";
+```
+
+Once you have the DB ready, you can set up the data structure and generate seed data:
 
 ```bash
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/db/migrations/20220526103422_init.js
+++ b/db/migrations/20220526103422_init.js
@@ -14,9 +14,6 @@ const secrets = {
  module.exports.up = async (knex, Promise) => {
   console.info('running migration 20220526103422_init');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-  await knex.raw('create extension if not exists "pgcrypto"');
-
   await knex.schema
     .createTable('notifications', function (t) {
       t.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v1mc()')).primary();

--- a/db/migrations/20220706100046_create_templates.js
+++ b/db/migrations/20220706100046_create_templates.js
@@ -5,8 +5,6 @@
 exports.up = async (knex) => {
   console.info('running migration 20220706100046_create_templates');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-
   await knex.schema
     .createTable('templates', function (t) {
       t.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v1mc()')).primary();

--- a/db/migrations/20220717183449_create_projects.js
+++ b/db/migrations/20220717183449_create_projects.js
@@ -5,8 +5,6 @@
  exports.up = async (knex) => {
   console.info('running migration 20220717183449_create_projects');
 
-  await knex.raw('create extension if not exists "uuid-ossp"');
-
   await knex.schema
     .createTable('projects', function (t) {
       t.string('id').unique().notNullable().primary();

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,33 +12,40 @@ services:
       DB_DATABASE: notifir
       DB_HOST: db
       DB_PORT: 5432
-      DB_USER: postgres
-      DB_PASSWORD: postgres
+      DB_USER: notifir
+      DB_PASSWORD: notifir
       NODE_ENV: "production"
     ports:
       - 3001:3001
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     networks:
       - notifir_network
-#   uncomment if you want to run init script
-#    volumes:
-#      - ./init.json:/notifir/api/init.json
+    # uncomment if you want to run init script
+    # volumes:
+    #   - ./init.json:/notifir/api/init.json
   db:
     container_name: notifir_db
-    image: postgres
+    image: postgres:11-alpine
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: notifir
+      POSTGRES_PASSWORD: notifir
       POSTGRES_DB: notifir
       POSTGRES_PORT: 5432
       POSTGRES_HOST: localhost
     ports:
       - 5432:5432
     volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
       - notifir_db_vol:/var/lib/postgresql/data
     networks:
       - notifir_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U notifir"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 networks:
   notifir_network:

--- a/knexfile.js
+++ b/knexfile.js
@@ -7,7 +7,7 @@ module.exports = {
     client: CLIENT,
     connection: {
       database: DB_DATABASE,
-      user: DB_USER, // Migrations have to be run as "superuser"
+      user: DB_USER,
       password: DB_PASSWORD,
       host: DB_HOST,
       port: DB_PORT,
@@ -24,7 +24,7 @@ module.exports = {
     client: CLIENT,
     connection: {
       database: DB_DATABASE,
-      user: DB_USER, // Migrations have to be run as "superuser"
+      user: DB_USER,
       password: DB_PASSWORD,
       host: "localhost",
       port: DB_PORT
@@ -41,7 +41,7 @@ module.exports = {
     client: CLIENT,
     connection: {
       database: DB_DATABASE,
-      user: DB_USER, // Migrations have to be run as "superuser"
+      user: DB_USER,
       password: DB_PASSWORD,
       host: DB_HOST,
       port: DB_PORT,

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -5,25 +5,27 @@ require("dotenv").config();
 const { DB_DATABASE, DB_USER, DB_PASSWORD } = process.env;
 const PORT = 4444
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 let pgContainer;
 let app;
 let knexClient
 
 beforeAll(async () => {
-  pgContainer = await new GenericContainer("postgres")
+  pgContainer = await new GenericContainer("postgres:11-alpine")
     .withEnv("POSTGRES_USER", DB_USER)
     .withEnv("POSTGRES_PASSWORD", DB_PASSWORD)
     .withEnv("POSTGRES_DB", DB_DATABASE)
     .withExposedPorts(5432)
     .start();
+
   process.env.DB_PORT = pgContainer.getMappedPort(5432);
-  process.env.PORT = PORT
+  process.env.PORT = PORT;
 
-  app = require("../src/app")
-  knexClient = require("../src/db")
+  app = require("../src/app");
+  knexClient = require("../src/db");
 
+  await knexClient.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
   await knexClient.migrate.latest();
   await knexClient.seed.run();
 });


### PR DESCRIPTION
I wish we could go with https://github.com/notifir/api/pull/16. However, we need to support older versions of Postgres.

This fix is about getting rid of `postgres` user dependency. The `uuid-ossp` extension should be installed outside of migration script - migrations are going to be run as `owner` user, while extension installation requires `superuser` permission. 